### PR TITLE
Reuse potentials

### DIFF
--- a/larch_cli_wrapper/feff_utils.py
+++ b/larch_cli_wrapper/feff_utils.py
@@ -1,9 +1,12 @@
 """FEFF input generation utilities - Fixed for consistent output between methods."""
 
+import concurrent
 import json
 import logging
 import os
 import re
+import subprocess
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -24,7 +27,6 @@ except ImportError:
     YAML_AVAILABLE = False
 
 from larch.io import read_ascii
-from larch.xafs.feffrunner import feff8l
 
 logger = logging.getLogger("larch_wrapper")
 
@@ -941,7 +943,7 @@ def run_multi_site_feff_calculations(
     cleanup: bool = True,
     parallel: bool = True,
     max_workers: int | None = None,
-    progress_callback: Callable = None,
+    progress_callback: Callable[[int, int], None] | None = None,
     timeout: int = 600,
     max_retries: int = 2,
 ) -> list[tuple[Path, bool]]:
@@ -959,13 +961,13 @@ def run_multi_site_feff_calculations(
             (default: 2)
 
     Returns:
-        List of (feff_dir, success) tuples
+        List of (feff_dir, success) tuples in the same order as input_files
     """
-    import concurrent.futures
-    import time
+    if not input_files:
+        return []
 
-    def run_single_calculation(input_file: Path) -> tuple[Path, bool]:
-        """Run FEFF calculation for a single site with retry logic."""
+    def run_with_retry(input_file: Path) -> tuple[Path, bool]:
+        """Run FEFF calculation with retry logic."""
         feff_dir = input_file.parent
 
         for attempt in range(max_retries + 1):
@@ -976,66 +978,84 @@ def run_multi_site_feff_calculations(
                     cleanup=cleanup,
                     timeout=timeout,
                 )
-
                 if success:
                     return feff_dir, True
 
-                # If not successful and not the last attempt, wait before retry
-                if attempt < max_retries:
-                    time.sleep(1 + attempt)  # Progressive backoff: 1s, 2s, 3s...
-
-            except (OSError, RuntimeError):
-                # Log the error but continue with retry logic
+                # Progressive backoff before retry (except on last attempt)
                 if attempt < max_retries:
                     time.sleep(1 + attempt)
-                else:
-                    # Final attempt failed
+
+            except (OSError, RuntimeError, TimeoutError):
+                # On final attempt, return failure
+                if attempt == max_retries:
                     return feff_dir, False
+                # Otherwise, wait and retry
+                time.sleep(1 + attempt)
 
         return feff_dir, False
+
+    # Determine if parallel execution is beneficial
+    use_parallel = parallel and len(input_files) > 1
+
+    if use_parallel:
+        return _run_parallel(
+            input_files, run_with_retry, max_workers, progress_callback
+        )
+    else:
+        return _run_sequential(input_files, run_with_retry, progress_callback)
+
+
+def _run_parallel(
+    input_files: list[Path],
+    task_fn: Callable[[Path], tuple[Path, bool]],
+    max_workers: int | None,
+    progress_callback: Callable[[int, int], None] | None,
+) -> list[tuple[Path, bool]]:
+    """Execute tasks in parallel using ThreadPoolExecutor."""
+    if max_workers is None:
+        cpu_count = os.cpu_count() or 4
+        max_workers = min(len(input_files), max(1, cpu_count // 2), 4)
 
     total_tasks = len(input_files)
     completed_count = 0
 
-    if parallel and len(input_files) > 1:
-        if max_workers is None:
-            # More conservative default: use fewer workers to reduce resource contention
-            cpu_count = os.cpu_count() or 4
-            max_workers = min(len(input_files), max(1, cpu_count // 2), 3)
-
-        results = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all tasks
-            future_to_input = {
-                executor.submit(run_single_calculation, input_file): input_file
-                for input_file in input_files
-            }
-
-            # Process results as they complete
-            for future in concurrent.futures.as_completed(future_to_input):
-                result = future.result()
-                results.append(result)
-                completed_count += 1
-
-                # Report progress
-                if progress_callback:
-                    progress_callback(completed_count, total_tasks)
-
-        # Reorder results to match original input order
-        input_to_result = {
-            future_to_input[future]: future.result() for future in future_to_input
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all tasks and maintain order mapping
+        future_to_input = {
+            executor.submit(task_fn, input_file): input_file
+            for input_file in input_files
         }
-        results = [input_to_result[input_file] for input_file in input_files]
-    else:
-        results = []
-        for input_file in input_files:
-            result = run_single_calculation(input_file)
-            results.append(result)
-            completed_count += 1
 
-            # Report progress for sequential execution
+        # Collect results as they complete (for progress tracking)
+        input_to_result = {}
+        for future in concurrent.futures.as_completed(future_to_input):
+            input_file = future_to_input[future]
+            result = future.result()
+            input_to_result[input_file] = result
+
+            completed_count += 1
             if progress_callback:
                 progress_callback(completed_count, total_tasks)
+
+    # Return results in original input order
+    return [input_to_result[input_file] for input_file in input_files]
+
+
+def _run_sequential(
+    input_files: list[Path],
+    task_fn: Callable[[Path], tuple[Path, bool]],
+    progress_callback: Callable[[int, int], None] | None,
+) -> list[tuple[Path, bool]]:
+    """Execute tasks sequentially."""
+    total_tasks = len(input_files)
+    results = []
+
+    for idx, input_file in enumerate(input_files, start=1):
+        result = task_fn(input_file)
+        results.append(result)
+
+        if progress_callback:
+            progress_callback(idx, total_tasks)
 
     return results
 
@@ -1099,11 +1119,11 @@ def generate_feff_input_multi(
 
 def run_feff_calculation(
     feff_dir: Path,
-    verbose: bool = False,
+    verbose: bool = True,
     cleanup: bool = True,
     timeout: int = 600,
 ) -> bool:
-    """Run FEFF calculation with robust encoding handling.
+    """Run FEFF calculation with robust error handling.
 
     Args:
         feff_dir: Directory containing feff.inp
@@ -1114,145 +1134,141 @@ def run_feff_calculation(
     Returns:
         True if calculation succeeded, False otherwise
     """
-    import shutil
-    import subprocess
-    import sys
-
     feff_dir = Path(feff_dir)
     input_path = feff_dir / "feff.inp"
     log_path = feff_dir / "feff.log"
     chi_file = feff_dir / "chi.dat"
+    phase_file = feff_dir / "phase.pad"
+    pot_file = feff_dir / "pot.pad"
 
     if not input_path.exists():
         raise FileNotFoundError(f"FEFF input file {input_path} not found")
 
     try:
-        # Create basic log
-        with open(log_path, "w", encoding="utf-8", errors="replace") as log_file:
-            log_file.write(f"FEFF calculation started at {datetime.now()}\n")
-            log_file.write(f"Input file: {input_path}\n")
-            log_file.write(f"Working directory: {feff_dir}\n")
-            log_file.write("-" * 50 + "\n\n")
+        # Initialize log file
+        _write_log_header(log_path, input_path, feff_dir)
 
-        # Try to use larch feff8l if available, but with encoding fix
-        try:
-            # Use larch's feff8l, but ensure proper encoding
+        # Run FEFF calculation
+        feff_command = ["feff8l"]
+        if verbose:
+            feff_command.append("-v")
 
-            if not verbose:
-                # Don't redirect stdout/stderr for non-verbose mode
-                # Instead, let feff8l handle its own output and capture it differently
-                os.environ["PYTHONIOENCODING"] = "utf-8"
+        _run_feff_subprocess(feff_command, feff_dir, log_path, timeout)
 
-                # Run with verbose=False but don't redirect streams
-                result = feff8l(folder=str(feff_dir), feffinp="feff.inp", verbose=False)
-            else:
-                # For verbose mode, ensure stdout has encoding
-                if not hasattr(sys.stdout, "encoding") or sys.stdout.encoding is None:
-                    sys.stdout.encoding = "utf-8"
-                result = feff8l(
-                    folder=str(feff_dir), feffinp="feff.inp", verbose=verbose
-                )
-
-        except Exception as larch_error:
-            # If larch fails, try using subprocess as fallback
-            with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
-                log_file.write(f"Larch feff8l failed: {larch_error}\n")
-                log_file.write("Attempting subprocess fallback...\n")
-
-            # Look for feff executable
-            feff_exe = shutil.which("feff8l") or shutil.which("feff")
-            if feff_exe is None:
-                raise RuntimeError("No FEFF executable found in PATH") from larch_error
-
-            # Validate executable path for security
-            feff_exe = Path(feff_exe).resolve()
-            if not feff_exe.exists() or not feff_exe.is_file():
-                raise RuntimeError(
-                    f"FEFF executable not found or not a file: {feff_exe}"
-                ) from larch_error
-
-            # Run FEFF via subprocess
-            try:
-                env = os.environ.copy()
-                env["PYTHONIOENCODING"] = "utf-8"
-
-                # Run FEFF via subprocess
-                # S603: subprocess call is safe here - executable path is validated
-                proc = subprocess.run(  # noqa: S603
-                    [str(feff_exe)],  # Convert Path to string for subprocess
-                    cwd=str(feff_dir),
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    env=env,
-                    timeout=timeout,  # Configurable timeout (default 10 minutes)
-                    check=False,  # Don't raise on non-zero exit codes
-                )
-
-                # Log subprocess output
-                with open(
-                    log_path, "a", encoding="utf-8", errors="replace"
-                ) as log_file:
-                    log_file.write(f"FEFF stdout:\n{proc.stdout}\n")
-                    if proc.stderr:
-                        log_file.write(f"FEFF stderr:\n{proc.stderr}\n")
-
-                result = proc.returncode == 0
-
-            except (
-                subprocess.TimeoutExpired,
-                subprocess.SubprocessError,
-            ) as proc_error:
-                with open(
-                    log_path, "a", encoding="utf-8", errors="replace"
-                ) as log_file:
-                    log_file.write(f"Subprocess failed: {proc_error}\n")
-                result = False
-
-        # Check success
-        chi_file = feff_dir / "chi.dat"
-        success = chi_file.exists() and bool(result)
+        # Check if calculation produced expected output files
+        success = _check_output_files(chi_file, phase_file, pot_file)
 
         # Clean up if requested and successful
         if success and cleanup:
             cleanup_feff_output(feff_dir, keep_essential=True)
 
-        # Log final result
-        with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
-            log_file.write(f"\nCalculation completed at {datetime.now()}\n")
-            log_file.write(f"Success: {success}\n")
-            if not chi_file.exists():
-                log_file.write("Warning: chi.dat file not found\n")
+        # Log results
+        _write_log_footer(log_path, success, chi_file, phase_file, pot_file)
 
         return success
 
-    except (
-        OSError,
-        subprocess.CalledProcessError,
-        FileNotFoundError,
-        PermissionError,
-        TimeoutError,
-    ) as e:
-        # Log any errors from FEFF execution or file operations
-        error_msg = str(e)
-        try:
-            with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
-                log_file.write(f"\nERROR: {error_msg}\n")
-                log_file.write(f"Exception type: {type(e).__name__}\n")
-        except OSError:
-            print(f"FEFF calculation failed: {error_msg}")
+    except subprocess.TimeoutExpired as e:
+        _handle_timeout_error(log_path, timeout, e)
+        return False
+    except (subprocess.CalledProcessError, OSError, PermissionError) as e:
+        _handle_general_error(log_path, e)
         return False
 
 
-def get_feff_numbered_files(feff_dir: Path) -> list[Path]:
+def _write_log_header(log_path: Path, input_path: Path, feff_dir: Path) -> None:
+    """Write initial log header."""
+    with open(log_path, "w", encoding="utf-8", errors="replace") as log_file:
+        log_file.write(f"FEFF calculation started at {datetime.now()}\n")
+        log_file.write(f"Input file: {input_path}\n")
+        log_file.write(f"Working directory: {feff_dir}\n")
+        log_file.write("-" * 50 + "\n\n")
+
+
+def _run_feff_subprocess(
+    command: list[str], cwd: Path, log_path: Path, timeout: int
+) -> None:
+    """Execute FEFF subprocess and capture output."""
+    # Simple safety check for command
+    if not command or not isinstance(command, list):
+        raise ValueError("Invalid FEFF command")
+    # Ensure all elements are strings
+    if not all(isinstance(arg, str) for arg in command):
+        raise ValueError("FEFF command arguments must be strings")
+
+    with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
+        log_file.write(f"Running command: {' '.join(command)}\n\n")
+        subprocess.run(  # noqa: S603
+            command,
+            cwd=cwd,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            check=True,
+        )
+
+
+def _check_output_files(chi_file: Path, phase_file: Path, pot_file: Path) -> bool:
+    """Check if expected output files exist.
+
+    Success criteria: chi.dat exists OR both phase.pad and pot.pad exist.
+    """
+    return chi_file.exists() or (phase_file.exists() and pot_file.exists())
+
+
+def _write_log_footer(
+    log_path: Path,
+    success: bool,
+    chi_file: Path,
+    phase_file: Path,
+    pot_file: Path,
+) -> None:
+    """Write final log summary."""
+    with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
+        log_file.write(f"\nCalculation completed at {datetime.now()}\n")
+        log_file.write(f"Success: {success}\n")
+        log_file.write("\nOutput files check:\n")
+        log_file.write(f"  chi.dat: {'✓' if chi_file.exists() else '✗'}\n")
+        log_file.write(f"  phase.pad: {'✓' if phase_file.exists() else '✗'}\n")
+        log_file.write(f"  pot.pad: {'✓' if pot_file.exists() else '✗'}\n")
+
+        if not success:
+            log_file.write(
+                "\nWarning: Neither chi.dat nor both phase.pad and pot.pad found\n"
+            )
+
+
+def _handle_timeout_error(log_path: Path, timeout: int, error: Exception) -> None:
+    """Handle subprocess timeout errors."""
+    error_msg = (
+        f"FEFF command timed out after {timeout}s. "
+        "Consider increasing the timeout or inspecting the input."
+    )
+    try:
+        with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
+            log_file.write(f"\nERROR: {error_msg}\n")
+            log_file.write(f"Exception: {error}\n")
+    except OSError:
+        print(f"FEFF calculation failed: {error_msg}")
+
+
+def _handle_general_error(log_path: Path, error: Exception) -> None:
+    """Handle general errors during FEFF execution."""
+    error_msg = f"{type(error).__name__}: {error}"
+    try:
+        with open(log_path, "a", encoding="utf-8", errors="replace") as log_file:
+            log_file.write(f"\nERROR: {error_msg}\n")
+    except OSError:
+        print(f"FEFF calculation failed: {error_msg}")
+
+
+def get_feff_numbered_files(feff_dir: Path, base_string="feff") -> list[Path]:
     """Get all feff####.dat files (any number of digits)."""
     feff_dir = Path(feff_dir)
     if not feff_dir.exists():
         return []
 
     # Simple regex: feff + digits + .dat (case insensitive)
-    pattern = re.compile(r"^feff\d+\.dat$", re.IGNORECASE)
+    pattern = re.compile(rf"^{base_string}\d+\.dat$", re.IGNORECASE)
 
     feff_files = []
     for file_path in feff_dir.iterdir():

--- a/larch_cli_wrapper/feff_utils.py
+++ b/larch_cli_wrapper/feff_utils.py
@@ -32,7 +32,16 @@ logger = logging.getLogger("larch_wrapper")
 LARGE_NUMBER_OF_SITES = 100
 
 # FEFF card fields that can be set to null in YAML to disable them
-FEFF_CARD_FIELDS = {"control", "print", "s02", "scf", "exchange", "nleg", "exafs"}
+FEFF_CARD_FIELDS = {
+    "control",
+    "print",
+    "s02",
+    "scf",
+    "exchange",
+    "nleg",
+    "exafs",
+    "criteria",
+}
 
 
 def _load_presets() -> dict[str, dict[str, Any]]:
@@ -236,6 +245,7 @@ class FeffConfig:
     exchange: Any | None = 0
     nleg: Any | None = 6
     exafs: Any | None = None
+    criteria: Any | None = None
 
     delete_tags: list[str] | str | None = (
         None  # Additional tags to delete (COREHOLE tags always deleted automatically)
@@ -455,6 +465,7 @@ class FeffConfig:
             "EXCHANGE": self.exchange,
             "NLEG": self.nleg,
             "EXAFS": self.exafs,
+            "CRITERIA": self.criteria,
         }
 
         # Add normalized explicit fields (skip None values)

--- a/larch_cli_wrapper/pipeline.py
+++ b/larch_cli_wrapper/pipeline.py
@@ -9,13 +9,19 @@ This module implements a clean separation of concerns:
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from shutil import copy2
 
 import numpy as np
 from ase import Atoms
 from ase.geometry import wrap_positions
 from larch import Group
 
-from .feff_utils import FeffConfig
+from .feff_utils import (
+    FeffConfig,
+    generate_multi_site_feff_inputs,
+    normalize_absorbers,
+    run_multi_site_feff_calculations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,11 +57,20 @@ class FeffTask:
 
 @dataclass
 class FeffBatch:
-    """Collection of FEFF tasks to be executed."""
+    """Collection of FEFF tasks to be executed.
+
+    This may contain a pre-compute task list that will generate potentials
+    to be re-used by subsequent tasks.
+    """
 
     tasks: list[FeffTask]
     output_dir: Path
     config: FeffConfig
+    precompute_tasks: list[FeffTask] = None
+
+    def get_precompute_tasks(self) -> list[FeffTask]:
+        """Get pre-compute tasks, if any."""
+        return self.precompute_tasks if self.precompute_tasks else []
 
     def get_tasks_by_frame(self) -> dict[int, list[FeffTask]]:
         """Group tasks by frame index."""
@@ -106,8 +121,6 @@ class InputGenerator:
         Returns:
             FeffBatch containing all tasks for this structure
         """
-        from .feff_utils import generate_multi_site_feff_inputs, normalize_absorbers
-
         # Normalize absorber specification
         absorber_indices = normalize_absorbers(structure, absorber)
 
@@ -138,6 +151,8 @@ class InputGenerator:
         structures: list[Atoms],
         absorber: str | int | list[int],
         output_dir: Path,
+        precompute_potentials: bool = False,
+        precompute_potentials_structure: Atoms = None,
     ) -> FeffBatch:
         """Generate inputs for trajectory with multiple frames.
 
@@ -145,23 +160,121 @@ class InputGenerator:
             structures: List of ASE Atoms objects (trajectory frames)
             absorber: Absorber specification
             output_dir: Base output directory
+            precompute_potentials: Whether to precompute potentials
+            precompute_potentials_structure: Structure to use for
+                                            precomputing potentials.
+                                            If None, uses the average
+                                            structure for all frames.
 
         Returns:
-            FeffBatch containing all tasks for all frames
+            FeffBatch containing all tasks for all frames,
+              with optional precompute tasks
         """
+        precompute_tasks = []
+        precompute_output_dir = None
+
+        if precompute_potentials:
+            # Determine structure for pre-computing potentials
+            if precompute_potentials_structure is None:
+                # Compute average structure
+                self.logger.info(
+                    "Computing average structure for pre-computing potentials"
+                )
+                precompute_potentials_structure = average_structure(structures)
+
+            self.logger.info("Pre-computing potentials for trajectory")
+            # Create pre-compute tasks
+            precompute_output_dir = output_dir / "precomputed_potentials"
+            precompute_output_dir.mkdir(parents=True, exist_ok=True)
+
+            # Write structure used for pre-computing potentials
+            structure_file = precompute_output_dir / "precompute_structure.extxyz"
+            precompute_potentials_structure.write(structure_file)
+
+            # Create config for precomputing (only potentials, no paths)
+            # CONTROL: ipot=1, ixsph=1, ifms=1, ipaths=0, igenfmt=0, iff2x=0
+            precompute_config = FeffConfig(**vars(self.config))
+            precompute_config.control = "1 1 1 0 0 0"
+
+            # Temporarily swap config to generate precompute inputs
+            original_config = self.config
+            self.config = precompute_config
+
+            try:
+                # Normalize absorber for the precompute structure
+                absorber_indices = normalize_absorbers(
+                    precompute_potentials_structure, absorber
+                )
+
+                # Generate FEFF inputs for precompute
+                input_files = generate_multi_site_feff_inputs(
+                    atoms=precompute_potentials_structure,
+                    absorber_indices=absorber_indices,
+                    base_output_dir=precompute_output_dir,
+                    config=precompute_config,
+                )
+
+                # Create precompute tasks
+                absorber_element = precompute_potentials_structure[
+                    absorber_indices[0]
+                ].symbol
+                for i, input_file in enumerate(input_files):
+                    task = FeffTask(
+                        input_file=input_file.resolve(),
+                        site_index=absorber_indices[i],
+                        frame_index=-1,  # Special marker for precompute tasks
+                        absorber_element=absorber_element,
+                    )
+                    precompute_tasks.append(task)
+
+                self.logger.info(
+                    f"Created {len(precompute_tasks)} precompute tasks for potentials"
+                )
+            finally:
+                # Restore original config
+                self.config = original_config
+
+            # Now prepare config for main tasks (paths only, reuse potentials)
+            # CONTROL: ipot=0, ixsph=0, ifms=0, ipaths=1, igenfmt=1, iff2x=1
+            main_config = FeffConfig(**vars(self.config))
+            main_config.control = "0 0 0 1 1 1"
+
+            self.logger.info(
+                "Generating main FEFF tasks to re-use pre-computed potentials"
+            )
+        else:
+            # No precompute - use original config
+            main_config = self.config
+
+        # Generate tasks for all frames
         all_tasks = []
 
-        for frame_idx, structure in enumerate(structures):
-            frame_dir = output_dir / f"frame_{frame_idx:04d}"
-            frame_batch = self.generate_single_site_inputs(
-                structure=structure,
-                absorber=absorber,
-                output_dir=frame_dir,
-                frame_index=frame_idx,
-            )
-            all_tasks.extend(frame_batch.tasks)
+        # Temporarily swap to main config if we're precomputing
+        if precompute_potentials:
+            original_config = self.config
+            self.config = main_config
 
-        return FeffBatch(tasks=all_tasks, output_dir=output_dir, config=self.config)
+        try:
+            for frame_idx, structure in enumerate(structures):
+                frame_dir = output_dir / f"frame_{frame_idx:04d}"
+                frame_batch = self.generate_single_site_inputs(
+                    structure=structure,
+                    absorber=absorber,
+                    output_dir=frame_dir,
+                    frame_index=frame_idx,
+                )
+                all_tasks.extend(frame_batch.tasks)
+        finally:
+            if precompute_potentials:
+                # Restore original config
+                self.config = original_config
+
+        return FeffBatch(
+            tasks=all_tasks,
+            output_dir=output_dir,
+            config=self.config,
+            precompute_tasks=precompute_tasks if precompute_potentials else None,
+        )
 
 
 class FeffExecutor:
@@ -253,6 +366,103 @@ class FeffExecutor:
             f"{' with caching' if self.cache_dir else ''}"
         )
 
+        # Execute precompute tasks first if they exist
+        if batch.precompute_tasks:
+            self.logger.info(
+                f"Executing {len(batch.precompute_tasks)} pre-compute "
+                f"FEFF calculations for potentials"
+            )
+
+            # Execute precompute without caching
+            precompute_input_files = [
+                task.input_file for task in batch.precompute_tasks
+            ]
+            precompute_results = run_multi_site_feff_calculations(
+                input_files=precompute_input_files,
+                cleanup=batch.config.cleanup_feff_files,
+                parallel=parallel,
+                max_workers=self.max_workers,
+                progress_callback=None,  # Don't report precompute progress separately
+            )
+
+            # Check all precompute tasks succeeded
+            all_succeeded = all(success for _, success in precompute_results)
+            if not all_succeeded:
+                failed_count = sum(
+                    1 for _, success in precompute_results if not success
+                )
+                self.logger.error(
+                    f"{failed_count} precompute tasks failed - "
+                    "main calculations may fail"
+                )
+            else:
+                self.logger.info("All precompute tasks completed successfully")
+
+                # NOW copy the precomputed potential files to all main task directories
+                self.logger.info(
+                    "Copying precomputed potential files to main task directories"
+                )
+                precompute_dir = batch.output_dir / "precomputed_potentials"
+                files_copied = 0
+
+                for task in batch.tasks:
+                    # Find the corresponding precompute site directory
+                    precompute_site_dir = precompute_dir / f"site_{task.site_index:04d}"
+
+                    if not precompute_site_dir.exists():
+                        self.logger.warning(
+                            "Precompute directory not found for "
+                            f"site {task.site_index}: {precompute_site_dir}"
+                        )
+                        continue
+
+                    # Create main task directory if needed
+                    task.feff_dir.mkdir(parents=True, exist_ok=True)
+
+                    # Copy essential potential files that FEFF needs to reuse potentials
+                    # These files are created by CONTROL 1 1 1 0 0 0
+                    # and needed by CONTROL 0 0 0 1 1 1
+                    potential_files = [
+                        # Core potential files
+                        "phase.pad",
+                        "pot.pad",
+                        # JSON files needed for path calculation
+                        "xsect.json",
+                        "xsph.json",
+                        "genfmt.json",
+                        "ff2x.json",
+                        "geom.json",
+                        "atoms.json",
+                        "pot.json",
+                        "global.json",
+                        "path.json",
+                        "libpotph.json",
+                        # Optional but useful
+                        "POTENTIALS",
+                    ]
+
+                    for filename in potential_files:
+                        src = precompute_site_dir / filename
+                        dst = task.feff_dir / filename
+
+                        if src.exists():
+                            try:
+                                copy2(src, dst)
+                                files_copied += 1
+                                self.logger.debug(
+                                    f"Copied {filename} to {task.feff_dir}"
+                                )
+                            except OSError as e:
+                                self.logger.error(f"Failed to copy {filename}: {e}")
+                        else:
+                            self.logger.warning(f"Required file not found: {src}")
+
+                expected_file_count = len(potential_files) * len(batch.tasks)
+                self.logger.info(
+                    f"Copied {files_copied} of {expected_file_count} "
+                    f"potential files across {len(batch.tasks)} main tasks"
+                )
+
         total_tasks = len(batch.tasks)
         completed_tasks = 0
 
@@ -323,8 +533,6 @@ class FeffExecutor:
 
         # Execute uncached calculations
         if tasks_to_run:
-            from .feff_utils import run_multi_site_feff_calculations
-
             input_files = [task.input_file for task, _ in tasks_to_run]
 
             # Create wrapper callback for FEFF calculations
@@ -594,10 +802,22 @@ class PipelineProcessor:
         output_dir: Path,
         parallel: bool = True,
         progress_callback: callable = None,
+        precompute_potentials: bool = False,
+        precompute_potentials_structure: Atoms = None,
         # site_weights: list[float] | None = None, # Not implemented yet
         # frame_weights: list[float] | None = None, # Not implemented yet
     ) -> tuple[Group, dict[int, Group], dict[int, Group], list[Group]]:
         """Process a trajectory with the three-stage approach.
+
+        Args:
+            structures: List of ASE Atoms objects (trajectory frames)
+            absorber: Absorber specification
+            output_dir: Base output directory
+            parallel: Whether to use parallel execution
+            progress_callback: Optional callback function
+            precompute_potentials: Whether to precompute potentials once and reuse
+            precompute_potentials_structure: Structure to use for
+                                             precompute (defaults to average)
 
         Returns:
             Tuple of (overall_average, frame_averages, actual_site_averages,
@@ -608,6 +828,8 @@ class PipelineProcessor:
             structures=structures,
             absorber=absorber,
             output_dir=output_dir,
+            precompute_potentials=precompute_potentials,
+            precompute_potentials_structure=precompute_potentials_structure,
         )
 
         # Stage B: Execute all FEFF calculations

--- a/larch_cli_wrapper/pipeline.py
+++ b/larch_cli_wrapper/pipeline.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import numpy as np
 from ase import Atoms
+from ase.geometry import wrap_positions
 from larch import Group
 
 from .feff_utils import FeffConfig
@@ -684,3 +685,77 @@ class PipelineProcessor:
             "cache_files": cache_info["files"],
             "cache_size_mb": cache_info["size_mb"],
         }
+
+
+def average_structure(structures: list[Atoms]) -> Atoms:
+    """Compute the average atomic positions across an ASE trajectory.
+
+    This function averages the atomic positions of multiple ASE Atoms objects,
+    correctly handling periodic boundary conditions.
+
+    It checks that all structures have the same atom types, number of atoms,
+    cell, and PBC settings.
+
+    It assumes that there are no large diffusive motions that
+    would cause atoms to jump > half the cell length from the initial frame.
+
+    Args:
+        structures : list[ase.Atoms]
+            List of ASE Atoms objects (e.g. frames from a trajectory).
+            All structures must have the same atom types, number of atoms,
+            cell, and PBC.
+
+    Returns:
+        avg_structure : ase.Atoms
+            A new ASE Atoms object containing the averaged structure.
+    """
+    if not structures:
+        raise ValueError("No structures provided")
+
+    ref_structure = structures[0]
+    n_atoms = len(ref_structure)
+    ref_symbols = ref_structure.get_chemical_symbols()
+    pbc = ref_structure.get_pbc()
+    cell = ref_structure.get_cell()
+
+    # Consistency checks
+    for i, s in enumerate(structures):
+        if len(s) != n_atoms:
+            raise ValueError(f"Structure {i} has {len(s)} atoms, expected {n_atoms}")
+        if s.get_chemical_symbols() != ref_symbols:
+            raise ValueError(f"Structure {i} has different atom types")
+        if not np.allclose(s.get_cell(), cell, atol=1e-10):
+            raise ValueError(f"Structure {i} has a different cell")
+        if not np.array_equal(s.get_pbc(), pbc):
+            raise ValueError(f"Structure {i} has different PBC")
+
+    # Copy reference as output container
+    avg_structure = ref_structure.copy()
+
+    # Convert all positions to fractional coordinates
+    frac_coords = np.array([s.get_scaled_positions() for s in structures])
+
+    # Unwrap fractional coordinates along trajectory to remove jumps
+    unwrapped_frac = np.zeros_like(frac_coords)
+    for atom_idx in range(n_atoms):
+        for coord_idx in range(3):
+            if pbc[coord_idx]:  # Only unwrap in periodic directions
+                unwrapped_frac[:, atom_idx, coord_idx] = np.unwrap(
+                    frac_coords[:, atom_idx, coord_idx], period=1.0
+                )
+            else:
+                unwrapped_frac[:, atom_idx, coord_idx] = frac_coords[
+                    :, atom_idx, coord_idx
+                ]
+
+    # Average in fractional coordinates
+    avg_frac = np.mean(unwrapped_frac, axis=0)
+
+    # Convert back to Cartesian coordinates using modern ASE Cell API
+    avg_positions = cell.cartesian_positions(avg_frac)
+
+    # Wrap positions back into unit cell
+    avg_positions = wrap_positions(avg_positions, cell, pbc=pbc)
+
+    avg_structure.set_positions(avg_positions)
+    return avg_structure

--- a/tests/test_average_structure.py
+++ b/tests/test_average_structure.py
@@ -1,0 +1,124 @@
+"""Unit tests for the average_structure function in pipeline.py."""
+
+import numpy as np
+import pytest
+from ase import Atoms
+
+from larch_cli_wrapper.pipeline import average_structure
+
+
+def test_basic_average_no_pbc():
+    atoms1 = Atoms("H2", positions=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], pbc=False)
+    atoms2 = Atoms("H2", positions=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], pbc=False)
+    avg = average_structure([atoms1, atoms2])
+    expected_pos = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)
+    assert avg.get_chemical_symbols() == ["H", "H"]
+
+
+def test_simple_average_with_pbc():
+    cell = [[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]]
+    atoms1 = Atoms("H", positions=[[0.5, 0.5, 0.5]], cell=cell, pbc=True)
+    atoms2 = Atoms("H", positions=[[0.7, 0.7, 0.7]], cell=cell, pbc=True)
+    avg = average_structure([atoms1, atoms2])
+    expected_pos = np.array([[0.6, 0.6, 0.6]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)
+
+
+def test_pbc_unwrapping_across_boundary():
+    cell = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    atoms1 = Atoms("H", positions=[[0.9, 0.5, 0.5]], cell=cell, pbc=True)
+    atoms2 = Atoms("H", positions=[[0.1, 0.5, 0.5]], cell=cell, pbc=True)
+    avg = average_structure([atoms1, atoms2])
+    expected_pos = np.array([[0.0, 0.5, 0.5]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)
+
+
+def test_multiple_atoms_pbc():
+    cell = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    atoms1 = Atoms(
+        "H2", positions=[[0.8, 0.5, 0.5], [0.2, 0.3, 0.4]], cell=cell, pbc=True
+    )
+    atoms2 = Atoms(
+        "H2", positions=[[0.2, 0.5, 0.5], [0.3, 0.3, 0.4]], cell=cell, pbc=True
+    )
+    avg = average_structure([atoms1, atoms2])
+    expected_pos = np.array([[0.0, 0.5, 0.5], [0.25, 0.3, 0.4]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)
+
+
+def test_non_orthogonal_cell():
+    cell = [[2.0, 0.5, 0.0], [0.0, 2.0, 0.5], [0.5, 0.0, 2.0]]
+    atoms1 = Atoms("H", positions=[[0.1, 0.1, 0.1]], cell=cell, pbc=True)
+    atoms2 = Atoms("H", positions=[[0.9, 0.9, 0.9]], cell=cell, pbc=True)
+    avg = average_structure([atoms1, atoms2])
+    assert np.all(avg.positions >= 0)
+    assert np.all(avg.positions <= np.max(cell))
+
+
+def test_mixed_pbc():
+    cell = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 10.0]]
+    pbc = [True, True, False]
+    atoms1 = Atoms("H", positions=[[0.9, 0.5, 5.0]], cell=cell, pbc=pbc)
+    atoms2 = Atoms("H", positions=[[0.1, 0.5, 5.0]], cell=cell, pbc=pbc)
+    avg = average_structure([atoms1, atoms2])
+    expected_pos = np.array([[0.0, 0.5, 5.0]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)
+
+
+def test_single_structure():
+    cell = [[2.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 2.0]]
+    atoms = Atoms("H", positions=[[0.5, 0.5, 0.5]], cell=cell, pbc=True)
+    avg = average_structure([atoms])
+    np.testing.assert_allclose(avg.positions, atoms.positions, atol=1e-10)
+
+
+def test_empty_list():
+    with pytest.raises(ValueError, match="No structures provided"):
+        average_structure([])
+
+
+def test_inconsistent_atom_count():
+    atoms1 = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    atoms2 = Atoms("H2", positions=[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    with pytest.raises(ValueError, match="Structure 1 has 2 atoms, expected 1"):
+        average_structure([atoms1, atoms2])
+
+
+def test_inconsistent_atom_types():
+    atoms1 = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    atoms2 = Atoms("He", positions=[[0.0, 0.0, 0.0]])
+    with pytest.raises(ValueError, match="Structure 1 has different atom types"):
+        average_structure([atoms1, atoms2])
+
+
+def test_different_cells_raises_error():
+    cell1 = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    cell2 = [[1.1, 0.0, 0.0], [0.0, 1.1, 0.0], [0.0, 0.0, 1.1]]
+    atoms1 = Atoms("H", positions=[[0.5, 0.5, 0.5]], cell=cell1, pbc=True)
+    atoms2 = Atoms("H", positions=[[0.5, 0.5, 0.5]], cell=cell2, pbc=True)
+
+    with pytest.raises(ValueError, match="Structure 1 has a different cell"):
+        average_structure([atoms1, atoms2])
+
+
+def test_trajectory_with_large_displacements():
+    """Test trajectory where atom oscillates across boundary.
+
+    The unwrapping will interpret 0.1 <-> 0.9 as small backward/forward
+    jumps (-0.2/+0.2) rather than large forward/backward jumps (+0.8/-0.8),
+    resulting in an average near 0.0.
+    """
+    cell = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    positions = [
+        [[0.1, 0.5, 0.5]],
+        [[0.9, 0.5, 0.5]],
+        [[0.1, 0.5, 0.5]],
+        [[0.9, 0.5, 0.5]],
+    ]
+    structures = [Atoms("H", positions=pos, cell=cell, pbc=True) for pos in positions]
+    avg = average_structure(structures)
+
+    # np.unwrap interprets this as [0.1, -0.1, 0.1, -0.1] -> mean ≈ 0.0
+    expected_pos = np.array([[0.0, 0.5, 0.5]])
+    np.testing.assert_allclose(avg.positions, expected_pos, atol=1e-10)


### PR DESCRIPTION
Add the option to re-use potentials, generated for some initial structure for a whole trajectory. This could either be provided by the user or generated automatically as the trajectory-averaged structure. This dramatically speeds up the pipeline for trajectories. If multiple sites per frame are used, the initial potential calculation happens once for each of the sites(=clusters). 

It also removes the attempts to use the larch python function to run feff8l. Instead it calls subprocess. This was the fallback previously, which (always) ended up being used. The larch function works in a standalone script, but when called from our pipeline something strange happens with the encoding/stdin/stderr and it fails, so we simplify here. 

Also adds the CRITERIA feff keyword support. In the future we should allow arbitrary keywords to be added/clarify how this can be done. 