### PR TITLE
Use imaginary part of χ(k) (second column of chi.dat) for ensemble av…

### DIFF
--- a/tests/test_feff_utils.py
+++ b/tests/test_feff_utils.py
@@ -667,7 +667,9 @@ class TestFeffOutput:
     
         with tempfile.TemporaryDirectory() as tmpdir:
             feff_dir = Path(tmpdir)
-            (feff_dir / "chi.dat").write_text("# FEFF format\n3.0 0.1 0.1118 0.4636\n4.0 0.2 0.2236 0.4636\n")
+            (feff_dir / "chi.dat").write_text(
+                "# FEFF format\n3.0 0.1 0.1118 0.4636\n4.0 0.2 0.2236 0.4636\n"
+            )
             chi, k = read_feff_output(feff_dir)
             expected_chi = mock_data.mag * np.sin(mock_data.phase)
             np.testing.assert_array_equal(k, mock_data.k)

--- a/tests/test_feff_utils.py
+++ b/tests/test_feff_utils.py
@@ -652,19 +652,19 @@ class TestFeffOutput:
             np.testing.assert_array_equal(chi, mock_data.chi)
             np.testing.assert_array_equal(k, mock_data.k)
 
-
     @patch("larch_cli_wrapper.feff_utils.read_ascii")
     def test_read_feff_output_mag_phase_format(self, mock_read_ascii):
         """Fallback when only mag/phase exist: chi = mag * sin(phase)."""
+
         class MockFeffData:
             def __init__(self):
                 self.k = np.array([3.0, 4.0])
                 self.mag = np.array([0.1118, 0.2236])
                 self.phase = np.array([0.4636, 0.4636])
-    
+
         mock_data = MockFeffData()
         mock_read_ascii.return_value = mock_data
-    
+
         with tempfile.TemporaryDirectory() as tmpdir:
             feff_dir = Path(tmpdir)
             (feff_dir / "chi.dat").write_text(
@@ -675,27 +675,26 @@ class TestFeffOutput:
             np.testing.assert_array_equal(k, mock_data.k)
             np.testing.assert_allclose(chi, expected_chi)
 
-    
     @patch("larch_cli_wrapper.feff_utils.read_ascii")
     def test_read_feff_output_prefers_chi_column(self, mock_read_ascii):
         """If chi column exists, return it verbatim."""
+
         class MockFeffData:
             def __init__(self):
                 self.k = np.array([3.0, 4.0])
                 self.chi = np.array([0.1, 0.2])
                 self.mag = np.array([0.1118, 0.2236])
                 self.phase = np.array([0.4636, 0.4636])
-    
+
         mock_data = MockFeffData()
         mock_read_ascii.return_value = mock_data
-    
+
         with tempfile.TemporaryDirectory() as tmpdir:
             feff_dir = Path(tmpdir)
             (feff_dir / "chi.dat").write_text("# FEFF format\n")
             chi, k = read_feff_output(feff_dir)
             np.testing.assert_array_equal(k, mock_data.k)
             np.testing.assert_array_equal(chi, mock_data.chi)
-
 
     def test_cleanup_feff_output(self):
         """Test cleanup_feff_output function."""


### PR DESCRIPTION
Changed χ(k) handling to read the second column from FEFF’s chi.dat (labelled chi, i.e. Im[χ̃]) directly and average that, matching EDACA.
χ remains a complex array in code, but only the real part is populated; the leftover complex-handling logic can be cleaned up later.